### PR TITLE
Disable clicks on the posts on details page

### DIFF
--- a/packages/orca-frontend/components/Post/PostCard/PostCard.tsx
+++ b/packages/orca-frontend/components/Post/PostCard/PostCard.tsx
@@ -34,9 +34,17 @@ interface PostCardProps {
   displayChannelName?: boolean;
   isCommentsOpen?: boolean;
   refetch?: any;
+  disableNavigation?: boolean;
 }
 
-const PostCard: FC<PostCardProps> = ({ post, queryKey, displayChannelName, isCommentsOpen, refetch }) => {
+const PostCard: FC<PostCardProps> = ({
+  post,
+  queryKey,
+  displayChannelName,
+  isCommentsOpen,
+  disableNavigation,
+  refetch,
+}) => {
   const authUser = useSelector((state: RootState) => state.auth.user);
   const [isTitleExpanded, setIsTitleExpanded] = useState(false);
   const [isCommentSectionOpen, setIsCommentSectionOpen] = useState(false);
@@ -70,6 +78,9 @@ const PostCard: FC<PostCardProps> = ({ post, queryKey, displayChannelName, isCom
   const toggleCommentSection = () => setIsCommentSectionOpen(!isCommentSectionOpen);
 
   const showComments = isCommentSectionOpen || isCommentsOpen;
+
+  const postCardTitle = <Title ref={titleRef}>{post.title}</Title>;
+  const postCardImage = <Image alt="post" src={post.image} />;
 
   return (
     <Root>
@@ -133,9 +144,13 @@ const PostCard: FC<PostCardProps> = ({ post, queryKey, displayChannelName, isCom
       {post.title && (
         <>
           <TitleContainer isTitleExpanded={isTitleExpanded} initialHeight={TITLE_INITIAL_HEIGHT}>
-            <Link color="text" href={`/post/${post._id}`} disableBorderOnHover>
-              <Title ref={titleRef}>{post.title}</Title>
-            </Link>
+            {disableNavigation ? (
+              postCardTitle
+            ) : (
+              <Link color="text" href={`/post/${post._id}`} disableBorderOnHover>
+                {postCardTitle}
+              </Link>
+            )}
           </TitleContainer>
 
           <SeeMore isTitleExpanded={isTitleExpanded}>
@@ -145,11 +160,14 @@ const PostCard: FC<PostCardProps> = ({ post, queryKey, displayChannelName, isCom
           </SeeMore>
         </>
       )}
-      {post.image && (
-        <Link href={`/post/${post._id}`} disableBorderOnHover fullWidth block>
-          <Image alt="post" src={post.image} />
-        </Link>
-      )}
+      {post.image &&
+        (disableNavigation ? (
+          postCardImage
+        ) : (
+          <Link href={`/post/${post._id}`} disableBorderOnHover fullWidth block>
+            {postCardImage}
+          </Link>
+        ))}
       <LikeAndCommentsCount hadData={likes || comments}>
         {likes}
         <div />

--- a/packages/orca-frontend/pages/post/[id].tsx
+++ b/packages/orca-frontend/pages/post/[id].tsx
@@ -25,7 +25,14 @@ const PostPage: FC<ProfilePageProps> = ({ post }) => {
       <Seo title={post.title} image={post.image} />
 
       <Container maxWidth="md" marginTop="sm">
-        <PostCard refetch={refetch} isCommentsOpen displayChannelName queryKey={['post', data._id]} post={data} />
+        <PostCard
+          refetch={refetch}
+          disableNavigation
+          isCommentsOpen
+          displayChannelName
+          queryKey={['post', data._id]}
+          post={data}
+        />
       </Container>
     </Layout>
   );


### PR DESCRIPTION
#### Added a new flag called `disableNavigation` on PostCard component. This will allow us to handle the navigation for the click on the postcard component.
I have added a flag to disable the navigation so default behavior will be clickable PostCard components.

#### My PR is a:

- [ ] 🐛 Bug fix `closes #number`
- [x] 💅 Enhancement `closes #136 `
- [ ] 🚀 New feature `closes #number`

#### Main update on the:

- [ ] orca-api
- [x] orca-frontend
- [ ] create-orca-app
- [ ] other

closes #136 
